### PR TITLE
[Compatibility fix] Additional LockerId/LockerData extension attributes

### DIFF
--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -4,4 +4,8 @@
         <attribute code="inpostinternational_locker_id" type="string"/>
         <attribute code="inpostinternational_locker_data" type="string"/>
     </extension_attributes>
+    <extension_attributes for="Magento\Checkout\Api\Data\ShippingInformationInterface">
+        <attribute code="inpostinternational_locker_id" type="string"/>
+        <attribute code="inpostinternational_locker_data" type="string"/>
+    </extension_attributes>
 </config>


### PR DESCRIPTION
Cause of the PR: Placing an order threw an error on a modified Magento instance.
I'm not sure whether the issue exists on a clean installation, but including this fix won't hurt.

`{"message":"Property \"InpostinternationalLockerId\" does not have accessor method \"getInpostinternationalLockerId\" in class \"Magento\\Checkout\\Api\\Data\\ShippingInformationExtensionInterface\".","trace":"[...]"}`